### PR TITLE
remove unnecessary JSON reformatting step from action.yml of galaxytools

### DIFF
--- a/galaxytool-import/action.yml
+++ b/galaxytool-import/action.yml
@@ -25,11 +25,3 @@ runs:
       run: |
         python ${{ github.action_path }}/galaxytool-import.py
       shell: bash
-
-    - name: reformat json to a predictable format with jq and sponge
-      run: |
-        sudo apt-get update -y
-        sudo apt-get install moreutils
-        FILES='*/*/*.galaxy.json'
-        for f in $FILES; do jq --indent 4 'walk( if type == "array" then sort else . end )'  $f | sponge $f; echo "processed $f file!"; done
-      shell: bash


### PR DESCRIPTION
This pull request includes a change to the `galaxytool-import/action.yml` file to remove the unnecessary step as the output was already formated in the python file.