### PR TITLE
Update Galaxy import

### DIFF
--- a/galaxytool-import/requirements.txt
+++ b/galaxytool-import/requirements.txt
@@ -1,3 +1,2 @@
 requests
 boltons
-pandas


### PR DESCRIPTION
The codex now also includes Related_Tutorials and Related_Workflows
This PR creates a complete link for the Related_Tutorials.
It also removes the json cleaning part:
```
  drop_false = lambda path, key, value: bool(value)
  tool_cleaned = remap(tool, visit=drop_false)
```
I think it's better to keep empty list (no workflows) or servers with 0 tools installed, that also information.