### PR TITLE
feat: generate biii dumps from versioned metadata

### DIFF
--- a/biii-import/biseEU_LD_export.py
+++ b/biii-import/biseEU_LD_export.py
@@ -17,6 +17,15 @@ def sanitize_html(text):
     return soup.get_text()
 
 
+def parse_datetime(value):
+    if isinstance(value, (int, float)):
+        return datetime.datetime.fromtimestamp(value)
+    try:
+        return datetime.datetime.fromisoformat(value)
+    except ValueError:
+        return datetime.datetime.fromtimestamp(float(value))
+
+
 # Intially due to SSL errors
 # urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
@@ -453,12 +462,12 @@ def rdfize_bioschema_tool(json_entry):
 
         for item in entry["created"]:
             if item["value"]:
-                date = datetime.datetime.fromisoformat(item["value"])
+                date = parse_datetime(item["value"])
                 out["dateCreated"] = str(date.isoformat())
 
         for item in entry["changed"]:
             if item["value"]:
-                date = datetime.datetime.fromisoformat(item["value"])
+                date = parse_datetime(item["value"])
                 out["dateModified"] = str(date.isoformat())
 
         for item in entry["field_is_dependent_of"]:
@@ -760,12 +769,12 @@ def rdfize(json_entry):
 
         for item in entry["created"]:
             if item["value"]:
-                date = datetime.datetime.fromtimestamp(item["value"])
+                date = parse_datetime(item["value"])
                 entry["dateCreated"] = str(date.isoformat())
 
         for item in entry["changed"]:
             if item["value"]:
-                date = datetime.datetime.fromtimestamp(item["value"])
+                date = parse_datetime(item["value"])
                 entry["dateModified"] = str(date.isoformat())
 
     except KeyError as e:

--- a/bioschemas-gen/biii_bioschemas_dump.py
+++ b/bioschemas-gen/biii_bioschemas_dump.py
@@ -1,0 +1,76 @@
+"""Build BIII RDF dumps from the records versioned in metadata-commons."""
+
+import importlib.util
+import json
+from pathlib import Path
+
+from rdflib import Graph
+
+
+def find_metadata_commons_root():
+    workspace = Path(__file__).resolve().parents[2]
+    candidates = (
+        workspace / "metadata-commons",
+        workspace / "content",
+        workspace,
+    )
+    for candidate in candidates:
+        if (candidate / "data").is_dir():
+            return candidate
+    raise FileNotFoundError("Could not locate the metadata-commons data directory")
+
+
+def load_biii_importer():
+    importer_path = (
+        Path(__file__).resolve().parents[1]
+        / "biii-import"
+        / "biseEU_LD_export.py"
+    )
+    spec = importlib.util.spec_from_file_location("biii_importer", importer_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def add_jsonld_files(graph, files):
+    for data_file in files:
+        graph.parse(data_file, format="json-ld")
+
+
+def build_bioschemas_dump(data_dir):
+    files = sorted(data_dir.glob("*/*.neubias.bioschemas.jsonld"))
+    print(f"found {len(files)} BIII Bioschemas descriptors")
+    graph = Graph()
+    add_jsonld_files(graph, files)
+    return graph
+
+
+def build_legacy_ontology_dump(data_dir):
+    files = sorted(data_dir.glob("*/*.neubias.raw.json"))
+    print(f"found {len(files)} raw BIII descriptors")
+    importer = load_biii_importer()
+    graph = Graph()
+    for data_file in files:
+        with data_file.open(encoding="utf-8") as source:
+            graph.parse(data=importer.rdfize(json.load(source)), format="json-ld")
+    return graph
+
+
+def process_tools():
+    repository = find_metadata_commons_root()
+    data_dir = repository / "data"
+    dataset_dir = repository / "datasets"
+    dataset_dir.mkdir(exist_ok=True)
+
+    build_bioschemas_dump(data_dir).serialize(
+        format="turtle",
+        destination=dataset_dir / "bioschemas-biii-dump.ttl",
+    )
+    build_legacy_ontology_dump(data_dir).serialize(
+        format="turtle",
+        destination=dataset_dir / "bise-ontology-biii-dump.ttl",
+    )
+
+
+if __name__ == "__main__":
+    process_tools()

--- a/bioschemas-gen/biii_bioschemas_dump.py
+++ b/bioschemas-gen/biii_bioschemas_dump.py
@@ -22,9 +22,7 @@ def find_metadata_commons_root():
 
 def load_biii_importer():
     importer_path = (
-        Path(__file__).resolve().parents[1]
-        / "biii-import"
-        / "biseEU_LD_export.py"
+        Path(__file__).resolve().parents[1] / "biii-import" / "biseEU_LD_export.py"
     )
     spec = importlib.util.spec_from_file_location("biii_importer", importer_path)
     module = importlib.util.module_from_spec(spec)

--- a/bioschemas-gen/bioconda_to_bioschemas.py
+++ b/bioschemas-gen/bioconda_to_bioschemas.py
@@ -41,32 +41,41 @@ def getMaintainers(bioconda_data) -> list:
                 res.append(id)
     return res
 
+
 def getDownloadUrl(bioconda_data) -> list:
-  """
-  Get URLs from the bioconda data.
-  """
-  res = []
-  if 'source' in bioconda_data.keys():
-    if not isinstance(bioconda_data['source'], dict):
-        print(f"WARNING: source is not a dictionary: {bioconda_data['source']}")
-    elif 'url' in bioconda_data['source'].keys() and isinstance(bioconda_data['source']['url'], list):
-        for url in bioconda_data['source']['url']:
-            res.append(url)
-    elif 'url' in bioconda_data['source'].keys() and isinstance(bioconda_data['source']['url'], str):
-            res.append(bioconda_data['source']['url'])
-  return res
-  
+    """
+    Get URLs from the bioconda data.
+    """
+    res = []
+    if "source" in bioconda_data.keys():
+        if not isinstance(bioconda_data["source"], dict):
+            print(f"WARNING: source is not a dictionary: {bioconda_data['source']}")
+        elif "url" in bioconda_data["source"].keys() and isinstance(
+            bioconda_data["source"]["url"], list
+        ):
+            for url in bioconda_data["source"]["url"]:
+                res.append(url)
+        elif "url" in bioconda_data["source"].keys() and isinstance(
+            bioconda_data["source"]["url"], str
+        ):
+            res.append(bioconda_data["source"]["url"])
+    return res
+
+
 def getDependencies(bioconda_data) -> list:
-  """
-  Get host dependencies from the bioconda data.
-  """
-  res = []
-  if 'requirements' in bioconda_data.keys():
-    if 'host' in bioconda_data['requirements'].keys() and bioconda_data['requirements']['host']:
-      for pkg in bioconda_data['requirements']['host']:
-        pkg = pkg.split(' ', 1)[0]
-        res.append(pkg)
-  return res
+    """
+    Get host dependencies from the bioconda data.
+    """
+    res = []
+    if "requirements" in bioconda_data.keys():
+        if (
+            "host" in bioconda_data["requirements"].keys()
+            and bioconda_data["requirements"]["host"]
+        ):
+            for pkg in bioconda_data["requirements"]["host"]:
+                pkg = pkg.split(" ", 1)[0]
+                res.append(pkg)
+    return res
 
 
 def rdfize(data) -> Graph:
@@ -141,7 +150,7 @@ def rdfize(data) -> Graph:
 
             for url in download_urls:
                 triples += f'{package_uri} schema:downloadUrl "{url}" .\n'
-    
+
             for dependency in dependencies:
                 triples += f'{package_uri} schema:hasPart "{dependency}" .\n'
 

--- a/bioschemas-gen/galaxyworkflows_bioschemas_dump.py
+++ b/bioschemas-gen/galaxyworkflows_bioschemas_dump.py
@@ -1,11 +1,5 @@
-
-#from pathlib import Path
-
-#from matplotlib.pylab import rint
 from rdflib import Graph
-#from rdflib import ConjunctiveGraph
 import requests
-#import yaml
 import json
 
 
@@ -15,38 +9,40 @@ kg = Graph()
 kg.parse(edam_version, format="xml")
 
 
-def getEdamUrisFromLabels(edam_labels) -> list :
-  """
-  Get EDAM URIs from EDAM labels.
-  """
+def getEdamUrisFromLabels(edam_labels) -> list:
+    """
+    Get EDAM URIs from EDAM labels.
+    """
 
-  res = []
+    res = []
 
-  for lab in edam_labels:
-    query="""
+    for lab in edam_labels:
+        query = """
     PREFIX edam: <http://edamontology.org/>
     PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 
     SELECT ?label ?entity WHERE {
         ?entity rdfs:label '%s' .
     }
-    """%(lab)
+    """ % (lab)
 
-    q = kg.query(query)
-    for r in q:
-        uri = r['entity'].rsplit('/', 1)[-1]
-        #url.rsplit('/', 1)
-        res.append(f'{uri}')
+        q = kg.query(query)
+        for r in q:
+            uri = r["entity"].rsplit("/", 1)[-1]
+            # url.rsplit('/', 1)
+            res.append(f"{uri}")
 
-  return res
+    return res
+
 
 def get_metadata(url):
-    
+
     response = requests.get(url)
-    response.raise_for_status() 
+    response.raise_for_status()
 
     data = json.loads(response.text)
     return data
+
 
 def rdfize(data) -> Graph:
 
@@ -60,35 +56,38 @@ def rdfize(data) -> Graph:
 
     triples = ""
 
-    #edam_operations = []
-    #edam_topics = []
-    #keywords = []
+    # edam_operations = []
+    # edam_topics = []
+    # keywords = []
 
     try:
-
         for entry in data:
-
             ## Minimum
             if "link" in entry.keys():
-                package_uri = f'<{entry["link"]}>'
-                triples += f'{package_uri} rdf:type schema:ComputationalWorkflow .\n'
+                package_uri = f"<{entry['link']}>"
+                triples += f"{package_uri} rdf:type schema:ComputationalWorkflow .\n"
                 triples += f'{package_uri} schema:url "{entry["link"]}" .\n'
-            
+
             if "name" in entry.keys():
-                triples += f"{package_uri} schema:name " + json.dumps(entry["name"]) + " .\n"
+                triples += (
+                    f"{package_uri} schema:name " + json.dumps(entry["name"]) + " .\n"
+                )
 
             if "description" in entry.keys():
-                triples += f"{package_uri} schema:description " + json.dumps(entry["description"]) + " .\n"
-
+                triples += (
+                    f"{package_uri} schema:description "
+                    + json.dumps(entry["description"])
+                    + " .\n"
+                )
 
             ## Recommended
             if "id" in entry.keys():
                 triples += f'{package_uri} schema:identifier "{entry["id"]}" .\n'
                 print(entry["id"])
-            
+
             if "doi" in entry.keys():
                 triples += f'{package_uri} schema:citation "{entry["doi"]}" .\n'
-        
+
             if "latest_version" in entry.keys():
                 triples += f'{package_uri} schema:softwareVersion "{entry["latest_version"]}" .\n'
 
@@ -102,44 +101,46 @@ def rdfize(data) -> Graph:
             if "edam_operation" in entry.keys():
                 ope = getEdamUrisFromLabels(entry["edam_operation"])
                 for o in ope:
-                    #edam_operations.append("edam:" + o)
+                    # edam_operations.append("edam:" + o)
                     triples += f'{package_uri} schema:featureList "{o}" .\n'
 
             if "edam_topic" in entry.keys():
                 top = getEdamUrisFromLabels(entry["edam_topic"])
                 for t in top:
-                    #edam_topics.append("edam:" + t)
+                    # edam_topics.append("edam:" + t)
                     triples += f'{package_uri} schema:applicationSubCategory "{t}" .\n'
 
             ## Optional
             if "create_time" in entry.keys():
-                triples += f'{package_uri} schema:dateCreated "{entry["create_time"]}" .\n'
+                triples += (
+                    f'{package_uri} schema:dateCreated "{entry["create_time"]}" .\n'
+                )
 
             if "update_time" in entry.keys():
-                triples += f'{package_uri} schema:dateModified "{entry["update_time"]}" .\n'
+                triples += (
+                    f'{package_uri} schema:dateModified "{entry["update_time"]}" .\n'
+                )
 
             if "tags" in entry.keys():
                 for tag in entry["tags"]:
                     triples += f'{package_uri} schema:keywords "{tag}" .\n'
-        
-    
+
         g = Graph()
-        g.parse(data=prefix+"\n"+triples, format="turtle")
-        print(g.serialize(format='turtle'))
+        g.parse(data=prefix + "\n" + triples, format="turtle")
+        print(g.serialize(format="turtle"))
         g.serialize(
             format="turtle",
             destination="../../content/datasets/galaxyworkflow-dump.ttl",
         )
 
-
-
     except Exception as e:
         print("PARSING ERROR for:")
-        print(prefix+"\n"+triples)
-        raise(e)
+        print(prefix + "\n" + triples)
+        raise (e)
+
 
 if __name__ == "__main__":
     url = "https://raw.githubusercontent.com/galaxyproject/galaxy_codex/refs/heads/main/communities/all/resources/workflows.json"
     data = get_metadata(url)
     rdfize(data)
-    #rdfize(data[1:1000])
+    # rdfize(data[1:1000])

--- a/bioschemas-gen/galaxyworkflows_bioschemas_dump.py
+++ b/bioschemas-gen/galaxyworkflows_bioschemas_dump.py
@@ -1,6 +1,5 @@
 
 #from pathlib import Path
-from urllib import response
 
 #from matplotlib.pylab import rint
 from rdflib import Graph

--- a/bioschemas-gen/requirements.txt
+++ b/bioschemas-gen/requirements.txt
@@ -2,3 +2,4 @@ requests
 rdflib
 tabulate
 pyyaml
+beautifulsoup4


### PR DESCRIPTION
This PR creates a dedicated dump script to generate the BIII-related dataset dumps:
* bioschemas-biii-dump.ttl
* bise-ontology-biii-dump.ttl

Instead of fetching live from BIII as current in the `content` repo, this script is strictly aimed at the new `metadata-commons` repo and creates pretty much identical files from the data that is versioned in the repo.

This new dump script will then be called together with all dump scripts to generate the artifact that is then pushed onto GHCR.