### PR TITLE
feat: add pandas to requirements.txt

### DIFF
--- a/bioschemas-gen/requirements.txt
+++ b/bioschemas-gen/requirements.txt
@@ -2,3 +2,4 @@ requests
 rdflib
 tabulate
 pyyaml
+pandas


### PR DESCRIPTION
There seems to be a missing dependency which has caused Actions in the metadata commons to fail.